### PR TITLE
Modify contactus URLs, and correct wedge-platform team to local-console team

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement
-[our contact form](https://developer.sony.com/contact-us/).
+[our contact form](https://support.aitrios.sony-semicon.com/hc/en-us/requests/new).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ If you find yourself wishing for a feature that doesn't exist, you are probably 
 > [!WARNING]
 > Do not use public issues to report security vulnerabilities: contact us directly instead.
 
-If you think that you have identified a security vulnerability in local-console, please send us your report with as much context as possible via [our contact form](https://developer.sony.com/contact-us/).
+If you think that you have identified a security vulnerability in local-console, please send us your report with as much context as possible via [our contact form](https://support.aitrios.sony-semicon.com/hc/en-us/requests/new).
 
 ## Contributing Code, Tests, and Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,7 @@ If you find yourself wishing for a feature that doesn't exist, you are probably 
 
 ## Security Vulnerabilities
 
-> **Warning**
->
+> [!WARNING]
 > Do not use public issues to report security vulnerabilities: contact us directly instead.
 
 If you think that you have identified a security vulnerability in local-console, please send us your report with as much context as possible via [our contact form](https://developer.sony.com/contact-us/).
@@ -49,10 +48,9 @@ In order to maintain proper traceability of contributions, we require that you a
 
 Our team members will review your PR, and once it is approved and passes continuous integration checks it will be ready to merge.
 
-Bear in mind that when you contribute a new feature, the maintenance burden is transferred to the wedge-platform team. This means that the benefit of the contribution must be compared against the cost of maintaining the feature.
+Bear in mind that when you contribute a new feature, the maintenance burden is transferred to the local-console team. This means that the benefit of the contribution must be compared against the cost of maintaining the feature.
 
-> **Warning**
->
+> [!WARNING]
 > By submitting a PR, you agree to license your work under the same license as that used by the project.
 
 ## License and Copyright


### PR DESCRIPTION
1. changes wedge-platform team => local-console team
2. Modify the URLs of the contact forms in CODE_OF_CONDUCT.md and CONTRIBUTING.md

Signed-off-by: Kenji SHIMIZU <kenji.shimizu@midokura.com>